### PR TITLE
DataAwareFilter interface to access additional data

### DIFF
--- a/src/Contracts/DataAwareFilter.php
+++ b/src/Contracts/DataAwareFilter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Elegant\Sanitizer\Contracts;
+
+interface DataAwareFilter
+{
+    /**
+     * Set the data under filtering.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data);
+}


### PR DESCRIPTION
Similar to `Illuminate\Contracts\Validation\DataAwareRule` for validation rules, there should be a way to access additional data of the current request inside a (custom) filter. So, instead of accessing `Request::input('otherfield')` from your filter's `apply()` method, you would just access the data via `$this->data['otherfield']`, e.g.:

```php
<?php

namespace App\Filters;

use App\Traits\DataAwareable;
use Elegant\Sanitizer\Contracts\DataAwareFilter;
use Elegant\Sanitizer\Contracts\Filter;

class NullUnless implements Filter, DataAwareFilter
{
    use DataAwareable;

    public function apply($value, array $options = [])
    {
        return in_array($this->data[array_shift($options)], $options) ? $value : null;
    }
}
```

my `App\Traits\DataAwareable` of that example simply implements the `setData()` method:

```php
<?php

namespace App\Traits;

/*
 * Trait for Illuminate\Contracts\Validation\DataAwareRule or Elegant\Sanitizer\Contracts\DataAwareFilter interface
 */
trait DataAwareable
{
    protected array $data;

    public function setData($data)
    {
        $this->data = $data;
        return $this;
    }
}
```

Like this, a filter could be unit tested. Additional data could be mocked or passed directly from the test.

Cheers,
Philip