### PR TITLE
Use dependency injection to instantiate filters

### DIFF
--- a/src/Laravel/Factory.php
+++ b/src/Laravel/Factory.php
@@ -25,7 +25,7 @@ class Factory
      */
     public function make(array $data, array $filters)
     {
-        $sanitizer = new Sanitizer($data, $filters, $this->extensions);
+        $sanitizer = new Sanitizer($data, $filters);
         $sanitizer->addExtensions($this->extensions);
         return $sanitizer;
     }

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -3,6 +3,7 @@
 namespace Elegant\Sanitizer;
 
 use Closure;
+use Illuminate\Container\Container;
 use InvalidArgumentException;
 use UnexpectedValueException;
 use Illuminate\Support\Arr;
@@ -26,6 +27,11 @@ class Sanitizer
      * @var array
      */
     protected $filters;
+
+    /**
+     * The Laravel dependency container.
+     */
+    protected Container $container;
 
     /**
      * Available filters as [name => classPath].
@@ -56,6 +62,7 @@ class Sanitizer
     {
         $this->data = $data;
         $this->filters = $this->parseFilters($filters);
+        $this->container = Container::getInstance();
     }
 
     /**
@@ -154,7 +161,9 @@ class Sanitizer
 
         // If the filter name is a class
         if (class_exists($name) and in_array(Filter::class, class_implements($name))) {
-            return (new $name)->apply($value, $options);
+            /** @var Filter $filter_instance */
+            $filter_instance = $this->container->make($name);
+            return $filter_instance->apply($value, $options);
         }
 
         // If the filter name, is not a class, then it should be inside availableFilters array

--- a/tests/Fixtures/Filters/CustomFilterWithDependency.php
+++ b/tests/Fixtures/Filters/CustomFilterWithDependency.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Elegant\Sanitizer\Tests\Fixtures\Filters;
+
+use Elegant\Sanitizer\Contracts\Filter;
+
+class CustomFilterWithDependency implements Filter
+{
+    public function __construct(private Dependency $dependency)
+    {
+    }
+
+    public function apply($value, array $options = [])
+    {
+        $this->dependency->call();
+
+        return $value;
+    }
+}

--- a/tests/Fixtures/Filters/Dependency.php
+++ b/tests/Fixtures/Filters/Dependency.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Elegant\Sanitizer\Tests\Fixtures\Filters;
+
+class Dependency
+{
+    private bool $called = false;
+
+    public function call()
+    {
+        $this->called = true;
+    }
+
+    public function isCalled(): bool
+    {
+        return $this->called;
+    }
+}

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -2,6 +2,9 @@
 
 namespace Elegant\Sanitizer\Tests;
 
+use Elegant\Sanitizer\Tests\Fixtures\Filters\CustomFilterWithDependency;
+use Elegant\Sanitizer\Tests\Fixtures\Filters\Dependency;
+use Illuminate\Container\Container;
 use InvalidArgumentException;
 use Elegant\Sanitizer\Laravel\Factory;
 use Elegant\Sanitizer\Tests\Fixtures\Filters\CustomFilter;
@@ -203,5 +206,22 @@ class SanitizerTest extends TestCase
 
         $this->assertArrayHasKey('title', $data);
         $this->assertNull($data['title']);
+    }
+
+    public function test_filter_from_container()
+    {
+        $container = Container::getInstance();
+        $dependency = new Dependency();
+        $container->instance(Dependency::class, $dependency);
+
+        $data = [
+            'name' => 'test',
+        ];
+        $filters = [
+            'name' => [CustomFilterWithDependency::class],
+        ];
+        $this->sanitize($data, $filters);
+
+        $this->assertTrue($dependency->isCalled());
     }
 }


### PR DESCRIPTION
Not everyone uses facades or singletons and instead want to get their dependencies injected in constructor. This change enables that.