### PR TITLE
Added support for multiple attributes for the same filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,27 @@ $filters = [
 ];
 ```
 
+#### Multiple attributes on the same line
+
+Avoid multiple lines of code for the same filter by simply listing the attributes separated by `,`:
+
+``` php
+use Elegant\Sanitizer\Sanitizer;
+
+$data = [
+    'name' => ' sina ',
+    'email' => 'JOHn@DoE.com',
+];
+
+$filters = [
+    'name,email' => 'trim|escape|lowercase',
+];
+
+$sanitizer = new Sanitizer($data, $filters);
+
+var_dump($sanitizer->sanitize());
+```
+
 ## Available Filters
 
 The following filters are available out of the box:

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -89,8 +89,16 @@ class Sanitizer
         $rawRules = (new ValidationRuleParser($this->data))->explode($filters);
 
         foreach ($rawRules->rules as $attribute => $attributeRules) {
-            foreach (array_filter($attributeRules) as $attributeRule) {
-                $parsed[$attribute][] = $this->parseFilter($attributeRule);
+            if(strpos($attribute, ',') !== false) {
+                foreach(array_filter(explode(',', $attribute)) as $splitedAttribute) {
+                    foreach (array_filter($attributeRules) as $attributeRule) {
+                        $parsed[trim($splitedAttribute)][] = $this->parseFilter($attributeRule);
+                    }
+                }
+            } else {
+                foreach (array_filter($attributeRules) as $attributeRule) {
+                    $parsed[$attribute][] = $this->parseFilter($attributeRule);
+                }
             }
         }
 


### PR DESCRIPTION
To avoid repetitions in code lines, it is now possible to use the same filter for multiple parameters separated by commas.