### PR TITLE
PHP 8.4

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -130,7 +130,7 @@ class Sanitizer
 
         if (strpos($filter, ':') !== false) {
             [$name, $options] = explode(':', $filter, 2);
-            $options = str_getcsv($options);
+            $options = str_getcsv($options, ',', '"', '\\');
         } else {
             $name = $filter;
             $options = [];


### PR DESCRIPTION
https://php.watch/versions/8.4/csv-functions-escape-parameter

- The `$escape` parameter must be provided in PHP 8.4